### PR TITLE
Gfx::Bitmap API scale_factor support

### DIFF
--- a/src/video/serenity/SDL_serenityvideo.cpp
+++ b/src/video/serenity/SDL_serenityvideo.cpp
@@ -585,7 +585,7 @@ int Serenity_CreateWindowFramebuffer(_THIS, SDL_Window* window, Uint32* format,
     *format = SDL_PIXELFORMAT_RGB888;
     win->m_widget->m_buffer = Gfx::Bitmap::create(
         Gfx::BitmapFormat::RGB32,
-        Gfx::IntSize(win->m_widget->width(), win->m_widget->height()));
+        Gfx::IntSize(win->m_widget->width(), win->m_widget->height()), 1);
     *pitch = win->m_widget->m_buffer->pitch();
     *pixels = win->m_widget->m_buffer->scanline(0);
     dbgprintf("Created framebuffer %dx%d\n", win->m_widget->width(),


### PR DESCRIPTION
This PR fixes compilation of SDL2 and apps using SDL2 that was failing due to recent changes in Gfx::Bitmap that added the new HighDPI mode