### PR TITLE
Initialize window framebuffer with BitmapFormat::BGRx8888.

### DIFF
--- a/src/video/serenity/SDL_serenityvideo.cpp
+++ b/src/video/serenity/SDL_serenityvideo.cpp
@@ -575,7 +575,7 @@ int Serenity_CreateWindowFramebuffer(_THIS, SDL_Window* window, Uint32* format,
     auto win = static_cast<SerenityPlatformWindow*>(window->driverdata);
     *format = SDL_PIXELFORMAT_RGB888;
     win->m_widget->m_buffer = Gfx::Bitmap::create(
-        Gfx::BitmapFormat::BGRA8888,
+        Gfx::BitmapFormat::BGRx8888,
         Gfx::IntSize(win->m_widget->width(), win->m_widget->height()));
     *pitch = win->m_widget->m_buffer->pitch();
     *pixels = win->m_widget->m_buffer->scanline(0);


### PR DESCRIPTION
Since we return SDL_PIXELFORMAT_RGB888 we should also create a bitmap without alpha channel since applications are free to ignore the last byte.