### PR TITLE
Change samples from 1000 to 1024

### DIFF
--- a/src/audio/serenity/SDL_serenityaudio.cpp
+++ b/src/audio/serenity/SDL_serenityaudio.cpp
@@ -69,7 +69,7 @@ static int SERENITYAUDIO_OpenDevice(_THIS, void*, const char*, int iscapture)
     that->spec.freq = 44100;
     that->spec.format = AUDIO_S16LSB;
     that->spec.channels = 2;
-    that->spec.samples = 1000;
+    that->spec.samples = 1024;
 
     /* Calculate the final parameters for this audio specification */
     SDL_CalculateAudioSpec(&that->spec);


### PR DESCRIPTION
Audio buffer sizes should really be a power of 2.
Most programs expect this, including ScummVM
(which was complaining about it) :)
