### PR TITLE
Draw partial screen updates to the correct position

### DIFF
--- a/src/video/serenity/SDL_serenityvideo.cpp
+++ b/src/video/serenity/SDL_serenityvideo.cpp
@@ -432,7 +432,7 @@ void SerenitySDLWidget::paint_event(GUI::PaintEvent& event)
     }
     GUI::Painter painter(*this);
     painter.add_clip_rect(event.rect());
-    painter.blit(Gfx::IntPoint(0, 0), *m_buffer, event.rect());
+    painter.blit(event.rect().location(), *m_buffer, event.rect());
 }
 void SerenitySDLWidget::resize_event(GUI::ResizeEvent&)
 {


### PR DESCRIPTION
OpenTTD does partial updates which all get drawn to `{0, 0}` on the screen. See https://www.youtube.com/watch?v=8GzECfHjVtU for an example.