### PR TITLE
Video: Create framebuffer bitmaps of the right size

### DIFF
--- a/src/video/serenity/SDL_serenityvideo.cpp
+++ b/src/video/serenity/SDL_serenityvideo.cpp
@@ -578,7 +578,7 @@ int Serenity_CreateWindowFramebuffer(_THIS, SDL_Window* window, Uint32* format,
     *format = SDL_PIXELFORMAT_RGB888;
     win->m_widget->m_buffer = Gfx::Bitmap::create(
         Gfx::BitmapFormat::BGRx8888,
-        Gfx::IntSize(win->m_widget->width(), win->m_widget->height()));
+        Gfx::IntSize(window->w, window->h));
     *pitch = win->m_widget->m_buffer->pitch();
     *pixels = win->m_widget->m_buffer->scanline(0);
     dbgln("Created framebuffer {}x{}", win->m_widget->width(), win->m_widget->height());


### PR DESCRIPTION
In `Serenity_CreateWindowFramebuffer`, we were creating a bitmap with a width and height corresponding to the dimensions of `m_widget`. However, these values can differ from the request which is put in `window->w` and `->h`, so use those values instead.

This allows ScummVM to switch to fullscreen and back.