### PR TITLE
Video: Use GFX::Bitmap::try_create

### DIFF
--- a/src/video/serenity/SDL_serenityvideo.cpp
+++ b/src/video/serenity/SDL_serenityvideo.cpp
@@ -554,7 +554,7 @@ static Gfx::Color get_color_from_sdl_pixel(SDL_PixelFormat const& format, u32 pi
 
 static RefPtr<Gfx::Bitmap> create_bitmap_from_surface(SDL_Surface& icon)
 {
-    auto bitmap = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, {icon.w, icon.h});
+    auto bitmap = Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRA8888, {icon.w, icon.h});
     if (!bitmap)
         return {};
 
@@ -607,7 +607,7 @@ int Serenity_CreateWindowFramebuffer(_THIS, SDL_Window* window, Uint32* format,
     dbgln("SDL2: Creating a new framebuffer of size {}x{}", window->w, window->h);
     auto win = SerenityPlatformWindow::from_sdl_window(window);
     *format = SDL_PIXELFORMAT_RGB888;
-    win->widget()->m_buffer = Gfx::Bitmap::create(
+    win->widget()->m_buffer = Gfx::Bitmap::try_create(
         Gfx::BitmapFormat::BGRx8888,
         Gfx::IntSize(window->w, window->h));
     *pitch = win->widget()->m_buffer->pitch();


### PR DESCRIPTION
LibGfx in SerenityOS has changed the static factory functions GFX::Bitmap::create to GFX::Bitmap::try_create.