### PR TITLE
Video: Call present on the gl context before updating the widget

### DIFF
--- a/src/video/serenity/SDL_serenityvideo.cpp
+++ b/src/video/serenity/SDL_serenityvideo.cpp
@@ -677,6 +677,9 @@ void* Serenity_GL_GetProcAddress(_THIS, const char* proc)
 int Serenity_GL_SwapWindow(_THIS, SDL_Window* window)
 {
     auto win = SerenityPlatformWindow::from_sdl_window(window);
+    if (win->widget()->m_gl_context)
+        win->widget()->m_gl_context->present();
+
     win->widget()->update();
     return 0;
 }


### PR DESCRIPTION
Before this change the opengl context was not actually displayed when swapping the buffers

## Description
Inserted a call to GLContext::present() before calling widget->update()

## Existing Issue(s)
No existing issue
