### PR TITLE
Audio+Video: Prevent AK from overriding std functions

### DIFF
--- a/src/audio/serenity/SDL_serenityaudio.cpp
+++ b/src/audio/serenity/SDL_serenityaudio.cpp
@@ -21,6 +21,7 @@
 #include "../../SDL_internal.h"
 
 #if SDL_AUDIO_DRIVER_SERENITY
+#    define AK_DONT_REPLACE_STD
 
 extern "C" {
 

--- a/src/video/serenity/SDL_serenityevents.cpp
+++ b/src/video/serenity/SDL_serenityevents.cpp
@@ -21,6 +21,7 @@
 #include "../../SDL_internal.h"
 
 #if SDL_VIDEO_DRIVER_SERENITY
+#define AK_DONT_REPLACE_STD
 
 #include "../../events/SDL_events_c.h"
 

--- a/src/video/serenity/SDL_serenitymessagebox.cpp
+++ b/src/video/serenity/SDL_serenitymessagebox.cpp
@@ -22,6 +22,7 @@
 #include "../../SDL_internal.h"
 
 #if SDL_VIDEO_DRIVER_SERENITY
+#    define AK_DONT_REPLACE_STD
 
 #    include "SDL_messagebox.h"
 #    include "SDL_serenitymessagebox.h"

--- a/src/video/serenity/SDL_serenitymouse.cpp
+++ b/src/video/serenity/SDL_serenitymouse.cpp
@@ -21,6 +21,7 @@
 #include "../../SDL_internal.h"
 
 #if SDL_VIDEO_DRIVER_SERENITY
+#define AK_DONT_REPLACE_STD
 
 /*
  * SDL includes:

--- a/src/video/serenity/SDL_serenityvideo.cpp
+++ b/src/video/serenity/SDL_serenityvideo.cpp
@@ -23,6 +23,7 @@ extern "C" {
 #include "../../SDL_internal.h"
 
 #if SDL_VIDEO_DRIVER_SERENITY
+#    define AK_DONT_REPLACE_STD
 
 #    include "../../events/SDL_events_c.h"
 #    include "../SDL_pixels_c.h"


### PR DESCRIPTION
This fixes build errors due to Serenity defining its own implementation
of std::move and std::forward.

## Description
Add `#define AK_DONT_REPLACE_STD` to all serenity specific source files
