### PR TITLE
serenityvideo: Bring mouse button names in-line with LibGUI

### DIFF
--- a/src/video/serenity/SDL_serenityvideo.cpp
+++ b/src/video/serenity/SDL_serenityvideo.cpp
@@ -443,11 +443,11 @@ static int map_button(GUI::MouseButton button)
     case GUI::MouseButton::None:
         VERIFY(false);
         break;
-    case GUI::MouseButton::Left:
+    case GUI::MouseButton::Primary:
         return SDL_BUTTON_LEFT;
     case GUI::MouseButton::Middle:
         return SDL_BUTTON_MIDDLE;
-    case GUI::MouseButton::Right:
+    case GUI::MouseButton::Secondary:
         return SDL_BUTTON_RIGHT;
     }
 


### PR DESCRIPTION
Broken since SerenityOS/serenity#10658 was merged.