### PR TITLE
Replace usages of FULL paths with their relative coutnerparts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2630,7 +2630,7 @@ if(NOT (WINDOWS OR CYGWIN))
   endif()
   install(PROGRAMS ${SDL2_BINARY_DIR}/sdl2-config DESTINATION bin)
   # TODO: what about the .spec file? Is it only needed for RPM creation?
-  install(FILES "${SDL2_SOURCE_DIR}/sdl2.m4" DESTINATION "${CMAKE_INSTALL_FULL_DATAROOTDIR}/aclocal")
+  install(FILES "${SDL2_SOURCE_DIR}/sdl2.m4" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/aclocal")
 endif()
 
 ##### Uninstall target #####


### PR DESCRIPTION
GNUInstallDirs currently doesn't support a separate STAGING directory, and will always prepend the final installation prefix to its paths.

Work around that by just using the path that is relative to the installation directory and let CMake figure out the rest.