### PR TITLE
Video: Load right LibGL dynamic library

### DIFF
--- a/src/video/serenity/SDL_serenityvideo.cpp
+++ b/src/video/serenity/SDL_serenityvideo.cpp
@@ -655,7 +655,7 @@ int Serenity_GL_LoadLibrary(_THIS, const char* path)
         return -1;
     }
 
-    _this->gl_config.dll_handle = dlopen("libgl.so", RTLD_LAZY | RTLD_LOCAL);
+    _this->gl_config.dll_handle = dlopen("libgl.so.serenity", RTLD_LAZY | RTLD_LOCAL);
     if (!_this->gl_config.dll_handle) {
         dbgln("Could not load OpenGL library: {}", dlerror());
         _this->gl_config.driver_loaded = SDL_FALSE;


### PR DESCRIPTION
The file `/usr/lib/libgl.so` is a symlink to `libgl.so.serenity`. Because `__dlopen()` considers the basename to be the library's name, two sets of memory regions for LibGL could be assigned to software using SDL.

For example, the `g_gl_context` pointer could be set for `libgl.so` but then cause a null deref in `libgl.so.serenity`.

Fix this by changing the `dlopen()` call to the right path.