### PR TITLE
Video: OpenGL context reinitialization improvements

### DIFF
--- a/src/video/serenity/SDL_serenityvideo.cpp
+++ b/src/video/serenity/SDL_serenityvideo.cpp
@@ -363,6 +363,7 @@ int SERENITY_VideoInit(_THIS)
 {
     VERIFY(!g_app);
     g_app = GUI::Application::construct(0, nullptr);
+    g_app->set_quit_when_last_window_deleted(false);
     SDL_DisplayMode mode;
 
     dbgln("SDL2: Initialising SDL application");

--- a/src/video/serenity/SDL_serenityvideo.cpp
+++ b/src/video/serenity/SDL_serenityvideo.cpp
@@ -631,8 +631,9 @@ int Serenity_UpdateWindowFramebuffer(_THIS, SDL_Window* window,
 
 void Serenity_DestroyWindowFramebuffer(_THIS, SDL_Window* window)
 {
-    auto win = SerenityPlatformWindow::from_sdl_window(window);
-    dbgln("DESTROY framebuffer {}x{}", win->widget()->width(), win->widget()->height());
+    auto widget = SerenityPlatformWindow::from_sdl_window(window)->widget();
+    dbgln("SDL2: Destroy framebuffer {}", widget->m_buffer->size());
+    widget->m_buffer = nullptr;
 }
 
 SDL_GLContext Serenity_GL_CreateContext(_THIS, SDL_Window* window)

--- a/src/video/serenity/SDL_serenityvideo.h
+++ b/src/video/serenity/SDL_serenityvideo.h
@@ -79,6 +79,19 @@ private:
     NonnullRefPtr<SerenitySDLWidget> m_widget;
 };
 
+class SerenityGLContext final {
+public:
+    explicit SerenityGLContext(SDL_Window& sdl_window)
+        : m_sdl_window(sdl_window)
+    {
+    }
+
+    SDL_Window& sdl_window() const { return m_sdl_window; }
+
+private:
+    SDL_Window& m_sdl_window;
+};
+
 #endif /* SDL_serenityvideo_h_ */
 
 /* vi: set ts=4 sw=4 expandtab: */


### PR DESCRIPTION
* Implement `GL_DeleteContext` and `GL_MakeCurrent`
* `DestroyWindowFramebuffer` now actually throws away the buffer
* Fixed: `GUI::Application` exiting the process when there are no more open windows

This allows ScummVM in OpenGL mode to progress beyond the launcher!