### PR TITLE
Video: Use the new `GL::present_context()` to prevent virtual resolution

### DIFF
--- a/src/video/serenity/SDL_serenityvideo.cpp
+++ b/src/video/serenity/SDL_serenityvideo.cpp
@@ -708,7 +708,7 @@ int Serenity_GL_SwapWindow(_THIS, SDL_Window* window)
 {
     auto win = SerenityPlatformWindow::from_sdl_window(window);
     if (win->widget()->m_gl_context)
-        win->widget()->m_gl_context->present();
+        GL::present_context(win->widget()->m_gl_context);
 
     win->widget()->update();
     return 0;


### PR DESCRIPTION
The SDL2 library was performing the virtual resolution into `GLContext::present()` itself, resulting in a lot of annoying recompilations (or issues if you forgot to recompile) whenever something changed in the definitions of `SoftwareGLContext`. By using the new `GL::present_context()` we delegate the resolution to `libgl.so`.

Before merging this, please merge this PR:
https://github.com/SerenityOS/serenity/pull/11148