### PR TITLE
Video: Repaint instead of update in `GL_SwapWindow`

### DIFF
--- a/src/video/serenity/SDL_serenityvideo.cpp
+++ b/src/video/serenity/SDL_serenityvideo.cpp
@@ -710,7 +710,7 @@ int Serenity_GL_SwapWindow(_THIS, SDL_Window* window)
     if (win->widget()->m_gl_context)
         GL::present_context(win->widget()->m_gl_context);
 
-    win->widget()->update();
+    win->widget()->repaint();
     return 0;
 }
 


### PR DESCRIPTION
The `widget->update()` we were doing was scheduling dirty rects to be eventually sent to the WindowServer. This means that SDL2 applications were not blocking on frame updates, making them render many more frames than were actually displayed on screen.

By invoking `widget->repaint()` instead, every rendered frame is now displayed making SDL2 applications feel much smoother. As a bonus, the new `LibSoftGPU` debug overlay now shows the correct FPS count.