### PR TITLE
Events: Keep pumping EventLoop until empty

### DIFF
--- a/src/video/serenity/SDL_serenityevents.cpp
+++ b/src/video/serenity/SDL_serenityevents.cpp
@@ -27,6 +27,7 @@
 
 #include "SDL_serenityvideo.h"
 #include "SDL_serenityevents_c.h"
+#include "SDL_timer.h"
 
 #include <LibCore/EventLoop.h>
 
@@ -36,7 +37,13 @@ SERENITY_PumpEvents(_THIS)
     auto& loop = Core::EventLoop::current();
     if (loop.was_exit_requested())
         exit(0);
-    loop.pump(Core::EventLoop::WaitMode::PollForEvents);
+
+    auto const event_loop_timeout_ms = SDL_GetTicks() + 100;
+    while (loop.pump(Core::EventLoop::WaitMode::PollForEvents) > 0) {
+        if (SDL_TICKS_PASSED(SDL_GetTicks(), event_loop_timeout_ms))
+            break;
+    }
+
 }
 
 


### PR DESCRIPTION
*Attention:* https://github.com/SerenityOS/serenity/pull/11659 needs to be merged first!

Events might dispatch other events that we may want to handle immediately rather than on the next iteration of PumpEvents.

For example, a mouse move event is sent to the Window as an IPC message which then dispatches a new mouse move event. This means that without this change, SDL applications only receive mouse move events every other frame.