### PR TITLE
Audio: Rewrite audio to use AudioServer

### DIFF
--- a/src/audio/serenity/SDL_serenityaudio.h
+++ b/src/audio/serenity/SDL_serenityaudio.h
@@ -23,11 +23,16 @@
 #pragma once
 
 #include "../SDL_sysaudio.h"
+#include <AK/OwnPtr.h>
+#include <AK/RefPtr.h>
+#include <LibAudio/ConnectionFromClient.h>
+#include <LibCore/EventLoop.h>
 
 #define _THIS SDL_AudioDevice* that
 
 struct SDL_PrivateAudioData {
-    int audio_fd { -1 };
+    RefPtr<Audio::ConnectionFromClient> client;
+    OwnPtr<Core::EventLoop> event_loop;
     Uint8* mixbuf { nullptr };
-    int mixlen { 0 };
+    size_t mixlen { 0 };
 };


### PR DESCRIPTION
:warning: Merge https://github.com/SerenityOS/serenity/pull/13820 _before_ this PR

Instead of writing directly to the `/dev/audio/0` character device, we now use a connection to Serenity's AudioServer instead. Amongst other advantages, this allows SDL applications to be properly mixed in with other audio clients.

With some help from @kleinesfilmroellchen :+1: