### PR TITLE
Audio: Remove include of the deprecated LibAudio buffer

### DIFF
--- a/src/audio/serenity/SDL_serenityaudio.cpp
+++ b/src/audio/serenity/SDL_serenityaudio.cpp
@@ -32,7 +32,6 @@ extern "C" {
 }
 
 #    include <AK/Time.h>
-#    include <LibAudio/Buffer.h>
 #    include <LibAudio/ConnectionFromClient.h>
 #    include <LibAudio/SampleFormats.h>
 #    include <time.h>


### PR DESCRIPTION
This was not actually in use, it's just... there.